### PR TITLE
Define error codes

### DIFF
--- a/draft-ietf-avtcore-rtp-over-quic.md
+++ b/draft-ietf-avtcore-rtp-over-quic.md
@@ -1197,19 +1197,15 @@ ROQ\_NO\_ERROR (0x????):
 : No error. This is used when the connection or stream needs to be closed, but
 there is no error to signal.
 
-ROQ\_GENERAL\_PROTOCOL\_ERROR (0x????):
-: Peer violated protocol requirements in a way that does not match a more
-specific error code or endpoint declines to use the more specific error code.
-
 ROQ\_INTERNAL\_ERROR (0x????):
 : An internal error has occured in the RoQ stack.
-
-ROQ\_STREAM\_CREATION\_ERROR (0x????):
-: The endpoint detected that its peer created a stream that it will not accept.
 
 ROQ\_PACKET\_ERROR (0x????):
 : Invalid payload format, e.g., length does not match packet, invalid flow id
 encoding, non-RTP on RTP-flow ID, etc.
+
+ROQ\_STREAM\_CREATION\_ERROR (0x????):
+: The endpoint detected that its peer created a stream that it will not accept.
 
 ROQ\_FRAME\_CANCELLED (0x????):
 : A receiving endpoint stopped reading a frame from a stream and requests new

--- a/draft-ietf-avtcore-rtp-over-quic.md
+++ b/draft-ietf-avtcore-rtp-over-quic.md
@@ -683,9 +683,10 @@ flow identifier of the RTP session in which the retransmission happens.
 
 # Connection Shutdown
 
-Both peers MAY close the connection for variety of reasons. If one of the peers
-wants to close the RoQ connection, the peer can use a QUIC CONNECTION\_CLOSE
-frame with one of the error codes defined in {{error-handling}}.
+Either peers MAY close the connection for variety of reasons. If one of the
+peers wants to close the RoQ connection, the peer can use a QUIC
+CONNECTION\_CLOSE frame with one of the error codes defined in
+{{error-handling}}.
 
 # Congestion Control and Rate Adaptation {#congestion-control}
 
@@ -1205,17 +1206,18 @@ ROQ\_PACKET\_ERROR (0x????):
 encoding, non-RTP on RTP-flow ID, etc.
 
 ROQ\_STREAM\_CREATION\_ERROR (0x????):
-: The endpoint detected that its peer created a stream that it will not accept.
+: The endpoint detected that its peer created a stream that violates the ROQ protocol.
 
 ROQ\_FRAME\_CANCELLED (0x????):
-: A receiving endpoint stopped reading a frame from a stream and requests new
-frames be sent on new streams using STOP\_SENDING or a sender notifies a
-receiver that retransmissions of a frame were stopped using RESET\_STREAM and
-new frames will be sent on new streams.
+: A receiving endpoint is using STOP_SENDING on the current stream to request
+new frames be sent on new streams. Similarly, a sender notifies a receiver that
+retransmissions of a frame were stopped using RESET\_STREAM and new frames will
+be sent on new streams.
 
 ROQ\_UNKNOWN\_FLOW\_ID (0x????):
 : An endpoint was unable to handle a flow identifier, e.g., because it was not
-signalled or it does not support multiplexing using arbitrary flow identifiers.
+signalled or because the endpoint does not support multiplexing using arbitrary
+flow identifiers.
 
 ROQ\_SIGNALING\_ERROR (0x????):
 : Parameters that were set during out of band signaling are incompatible with

--- a/draft-ietf-avtcore-rtp-over-quic.md
+++ b/draft-ietf-avtcore-rtp-over-quic.md
@@ -1364,6 +1364,20 @@ The "rtp-mux-quic" string identifies RoQ:
   Specification:
   : This document
 
+## RoQ Error Codes
+
+This document establishes a registry for RoQ error codes.
+
+| Name                          | Value  | Description                            | Specification  |
+| ----------------------------- | ------ | -------------------------------------- | -------------- |
+| ROQ\_NO\_ERROR                | 0x???? | No Error                               | TODO: This doc |
+| ROQ\_INTERNAL\_ERROR          | 0x???? | Internal Error                         | TODO: This doc |
+| ROQ\_PACKET\_ERROR            | 0x???? | Invalid payload format                 | TODO: This doc |
+| ROQ\_STREAM\_CREATION\_ERROR  | 0x???? | Invalid stream type                    | TODO: This doc |
+| ROQ\_FRAME\_CANCELLED         | 0x???? | Frame cancelled                        | TODO: This doc |
+| ROQ\_UNKNOWN\_FLOW\_ID        | 0x???? | Unknown Flow ID                        | TODO: This doc |
+| ROQ\_SIGNALING\_ERROR         | 0x???? | Externally signalled requirement unmet | TODO: This doc |
+
 --- back
 
 # List of optional QUIC Extensions

--- a/draft-ietf-avtcore-rtp-over-quic.md
+++ b/draft-ietf-avtcore-rtp-over-quic.md
@@ -632,7 +632,7 @@ extension to QUIC described in {{!RFC9221}}. QUIC datagrams can only be used if
 the use of the extension was successfully negotiated during the QUIC handshake.
 If the use of an extension was signaled using a signaling protocol, but the
 extension was not negotiated during the QUIC handshake, a peer MAY close the
-connection with the ROQ\_SIGNALING\_ERROR error code.
+connection with the ROQ\_EXPECTATION\_UNMET error code.
 
 QUIC datagrams preserve frame boundaries. Thus, a single RTP packet can be
 mapped to a single QUIC datagram without additional framing. Senders SHOULD
@@ -1222,10 +1222,9 @@ ROQ\_UNKNOWN\_FLOW\_ID (0x????):
 signalled or because the endpoint does not support multiplexing using arbitrary
 flow identifiers.
 
-ROQ\_SIGNALING\_ERROR (0x????):
-: Parameters that were set during out of band signaling are incompatible with
-the connection properties that were negotiated when the connection was
-established using QUIC transport parameters.
+ROQ\_EXPECTATION\_UNMET (0x????):
+: Expectiations of the QUIC transport set by RoQ out-of-band signalling were not
+met by the QUIC connection.
 
 # API Considerations {#api-considerations}
 
@@ -1380,7 +1379,7 @@ This document establishes a registry for RoQ error codes.
 | ROQ\_STREAM\_CREATION\_ERROR  | 0x???? | Invalid stream type                    | TODO: This doc |
 | ROQ\_FRAME\_CANCELLED         | 0x???? | Frame cancelled                        | TODO: This doc |
 | ROQ\_UNKNOWN\_FLOW\_ID        | 0x???? | Unknown Flow ID                        | TODO: This doc |
-| ROQ\_SIGNALING\_ERROR         | 0x???? | Externally signalled requirement unmet | TODO: This doc |
+| ROQ\_EXPECTATION\_UNMET       | 0x???? | Externally signalled requirement unmet | TODO: This doc |
 
 --- back
 

--- a/draft-ietf-avtcore-rtp-over-quic.md
+++ b/draft-ietf-avtcore-rtp-over-quic.md
@@ -630,8 +630,8 @@ stream credits it will have to provide to the media-sending peer.
 Senders can also transmit RTP packets in QUIC datagrams. QUIC datagrams are an
 extension to QUIC described in {{!RFC9221}}. QUIC datagrams can only be used if
 the use of the extension was successfully negotiated during the QUIC handshake.
-If the use of datagrams was signalled using a signalling protocol, but the
-datagram extension was not negotiated during the handshake, a peer MAY close the
+If the use of an extension was signaled using a signaling protocol, but the
+extension was not negotiated during the QUIC handshake, a peer MAY close the
 connection with the ROQ\_SIGNALING\_ERROR error code.
 
 QUIC datagrams preserve frame boundaries. Thus, a single RTP packet can be
@@ -1222,7 +1222,7 @@ flow identifiers.
 ROQ\_SIGNALING\_ERROR (0x????):
 : Parameters that were set during out of band signaling are incompatible with
 the connection properties that were negotiated when the connection was
-established using transport parameters.
+established using QUIC transport parameters.
 
 # API Considerations {#api-considerations}
 

--- a/draft-ietf-avtcore-rtp-over-quic.md
+++ b/draft-ietf-avtcore-rtp-over-quic.md
@@ -1198,6 +1198,9 @@ ROQ\_NO\_ERROR (0x????):
 : No error. This is used when the connection or stream needs to be closed, but
 there is no error to signal.
 
+ROQ\_GENERAL\_ERROR (0x????):
+: An error that does not match a more specific error code occured.
+
 ROQ\_INTERNAL\_ERROR (0x????):
 : An internal error has occured in the RoQ stack.
 
@@ -1371,6 +1374,7 @@ This document establishes a registry for RoQ error codes.
 | Name                          | Value  | Description                            | Specification  |
 | ----------------------------- | ------ | -------------------------------------- | -------------- |
 | ROQ\_NO\_ERROR                | 0x???? | No Error                               | TODO: This doc |
+| ROQ\_GENERAL\_ERROR           | 0x???? | General error                          | TODO: This doc |
 | ROQ\_INTERNAL\_ERROR          | 0x???? | Internal Error                         | TODO: This doc |
 | ROQ\_PACKET\_ERROR            | 0x???? | Invalid payload format                 | TODO: This doc |
 | ROQ\_STREAM\_CREATION\_ERROR  | 0x???? | Invalid stream type                    | TODO: This doc |

--- a/draft-ietf-avtcore-rtp-over-quic.md
+++ b/draft-ietf-avtcore-rtp-over-quic.md
@@ -1166,6 +1166,46 @@ jitter calculation, which can be done in QUIC if a timestamp extension is used.
 | urn:ietf:params:rtp-hdrext:sdes:CaptId | CLUE CaptId | [RFC8849] | no |
 | urn:ietf:params:rtp-hdrext:sdes:mid | Media identification | [RFC9143] | no |
 
+# Error Handling
+
+The following error codes are defined for use when abruptly terminating streams,
+aborting reading of streams, or immediately closing RoQ connections.
+
+## RoQ Error Codes
+
+ROQ\_NO\_ERROR (0x????):
+: No error. This is used when the connection or stream needs to be closed, but
+there is no error to signal.
+
+ROQ\_GENERAL\_PROTOCOL\_ERROR (0x????):
+: Peer violated protocol requirements in a way that does not match a more
+specific error code or endpoint declines to use the more specific error code.
+
+ROQ\_INTERNAL\_ERROR (0x????):
+: An internal error has occured in the RoQ stack.
+
+ROQ\_STREAM\_CREATION\_ERROR (0x????):
+: The endpoint detected that its peer created a stream that it will not accept.
+
+ROQ\_PACKET\_ERROR (0x????):
+: Invalid payload format, e.g., length does not match packet, invalid flow id
+encoding, non-RTP on RTP-flow ID, etc.
+
+ROQ\_FRAME\_CANCELLED (0x????):
+: A receiving endpoint stopped reading a frame from a stream and requests new
+frames be sent on new streams using STOP\_SENDING or a sender notifies a
+receiver that retransmissions of a frame were stopped using RESET\_STREAM and
+new frames will be sent on new streams.
+
+ROQ\_UNKNOWN\_FLOW\_ID (0x????):
+: An endpoint was unable to handle a flow identifier, e.g., because it was not
+signalled or it does not support multiplexing using arbitrary flow identifiers.
+
+ROQ\_SIGNALING\_ERROR (0x????):
+: Parameters that were set during out of band signaling are incompatible with
+the connection properties that were negotiated when the connection was
+established using transport parameters.
+
 # API Considerations {#api-considerations}
 
 The mapping described in the previous sections poses some interface requirements


### PR DESCRIPTION
Actual codes are still missing to avoid redefining them multiple times if we add more codes.