### PR TITLE
Add @spencerdawkins as third author

### DIFF
--- a/draft-ietf-avtcore-rtp-over-quic.md
+++ b/draft-ietf-avtcore-rtp-over-quic.md
@@ -24,6 +24,11 @@ author:
     name: Mathis Engelbart
     organization: Technical University Munich
     email: mathis.engelbart@gmail.com
+ -
+    ins: S. Dawkins
+    name: Spencer Dawkins
+    organization: Tencent America LLC
+    email: spencerdawkins.ietf@gmail.com
 
 informative:
 


### PR DESCRIPTION
Just FYI, it's fine with me (and perhaps preferable for @adoba and @JonathanLennox, since WG chairs are responsible for assigning authors/editors to working group drafts) if you wait to merge this PR, and we present it as an open issue at IETF 117. 

But at least it's in the repo now. 

close #104 